### PR TITLE
Shifts to cdnjs for prismjs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 
 <meta charset="utf-8" />
 <title>Awesomplete: Ultra lightweight, highly customizable, simple autocomplete, by Lea Verou</title>
-<link rel="stylesheet" href="http://prismjs.com/themes/prism.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.css" />
 <link rel="stylesheet" href="awesomplete.css" />
 <link rel="stylesheet" href="style.css" />
 
@@ -310,7 +310,7 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 <footer>Made with &hearts; by <a href="http://lea.verou.me">Lea Verou</a> &bull; <a href="http://lea.verou.me/2015/02/awesomplete-2kb-autocomplete-with-zero-dependencies">Read the blog post</a> &bull; <a href="http://shop.oreilly.com/product/0636920031123.do">Buy my book!</a> </footer>
 
 <script src="awesomplete.js"></script>
-<script src="http://prismjs.com/prism.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.js" defer></script>
 <script>
 $ = Awesomplete.$;
 $$ = Awesomplete.$$;


### PR DESCRIPTION
The old links were getting blocked over HTTPS.
