### PR TITLE
Init only after dom loaded

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -279,11 +279,19 @@ _.SORT_BYLENGTH = function (a, b) {
 
 function regEscape(s) { return s.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&"); }
 
-window.document.addEventListener('DOMContentLoaded', function () {
+function init() {
 	$$("input.awesomplete").forEach(function (input) {
 		new Awesomplete(input);
 	});
-});
+}
+
+// DOM already loaded?
+if (document.readyState !== "loading") {
+	init();
+} else {
+	// Wait for it
+	document.addEventListener("DOMContentLoaded", init);
+}
 
 _.$ = $;
 _.$$ = $$;

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -279,8 +279,10 @@ _.SORT_BYLENGTH = function (a, b) {
 
 function regEscape(s) { return s.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&"); }
 
-$$("input.awesomplete").forEach(function (input) {
-	new Awesomplete(input);
+window.document.addEventListener('DOMContentLoaded', function () {
+	$$("input.awesomplete").forEach(function (input) {
+		new Awesomplete(input);
+	});
 });
 
 _.$ = $;


### PR DESCRIPTION
The first thing I tried was something like:

```
<!doctype html>
<script src='awesomplete.js'></script>
<input class=awesomplete data-list='blah, blablah, blablablah, blargh'>
```

This didn't work, though, because awesomplete needed the DOM to be loaded when it initializes.

This PR makes it wait until the DOM has been loaded, so you can put the awesomplete.js directly into `<head>` and it will work just as well as if you put it at the end of `<body>`.

The technique is basically what jQuery does (https://github.com/addyosmani/jquery.parts/blob/master/jquery.documentReady.js), except that it might not work for historical browsers (didn't test on IE either).
