### PR TITLE
Link(s) to license

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,7 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 		<li><a href="https://github.com/LeaVerou/awesomplete">Fork me on Github</a></li>
 		<li><a href="https://github.com/LeaVerou/awesomplete/issues/new">File a bug</a> </li>
 		<li><a href="https://github.com/LeaVerou/awesomplete/issues/new">Suggest a feature</a> </li>
+		<li><a href="LICENSE">LICENSE</a></li>
 	</ul>
 	
 	<p><strong>Pull requests are very welcome</strong>, as long as you maintain the code style and ask before adding tons of LOCs to the codebase!</p>

--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 		<li><a href="https://github.com/LeaVerou/awesomplete">Fork me on Github</a></li>
 		<li><a href="https://github.com/LeaVerou/awesomplete/issues/new">File a bug</a> </li>
 		<li><a href="https://github.com/LeaVerou/awesomplete/issues/new">Suggest a feature</a> </li>
-		<li><a href="LICENSE">LICENSE</a></li>
+		<li><a href="LICENSE">LICENSE</a> (<a href="https://github.com/LeaVerou/awesomplete/blob/gh-pages/LICENSE">Github view</a>)</li>
 	</ul>
 	
 	<p><strong>Pull requests are very welcome</strong>, as long as you maintain the code style and ask before adding tons of LOCs to the codebase!</p>


### PR DESCRIPTION
@petetnt - 922c74189e459322599ecbf5a861115633ff7c2f was for the issue you mentioned. I figure linking to the actual version in the repo is useful in case people fork and add complications, although admittedly it isn't ideal having two links.
