### PR TITLE
"new" keyword not necessary anymore

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -8,6 +8,8 @@
 (function () {
 
 var _ = self.Awesomplete = function (input, o) {
+	if(!(this instanceof Awesomplete)) return new Awesomplete(input, o);
+
 	var me = this;
 	
 	// Setup


### PR DESCRIPTION
Hey there,

When you try to use the plugin without the `new` keyword it would return some errors, this PR menages to fix it.

I still think using the `new` keyword a good idea, but it's not strictly necessary anymore.
