### PR TITLE
Allow numerical options set to zero

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -269,7 +269,7 @@ function configure(properties, o) {
 		    attrValue = this.input.getAttribute("data-" + i.toLowerCase());
 
 		if (typeof initial === "number") {
-			this[i] = +attrValue;
+			this[i] = parseInt(attrValue);
 		}
 		else if (initial === false) { // Boolean options must be false by default anyway
 			this[i] = attrValue !== null;
@@ -281,7 +281,9 @@ function configure(properties, o) {
 			this[i] = attrValue;
 		}
 
-		this[i] = this[i] || o[i] || initial;
+		if (!this[i] && this[i] !== 0) {
+			this[i] = (i in o)? o[i] : initial;
+		}
 	}
 }
 


### PR DESCRIPTION
Adjusts the configuration logic to allow numerical options, such as minchars, to be set to zero (as mentioned in #1030).
- Apply JS option before normalizing values (only if HTML attribute is not present)
- Check if numerical value is specified (not null) before converting to
  integer
- Don’t fall back to initial value when option is set to zero
