### PR TITLE
Add an event for when the highlighted item changes

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -176,6 +176,8 @@ _.prototype = {
 			lis[i].setAttribute("aria-selected", "true");
 			this.status.textContent = lis[i].textContent;
 		}
+
+		$.fire(this.input, "awesomplete-highlight");
 	},
 
 	select: function (selected) {

--- a/index.html
+++ b/index.html
@@ -271,6 +271,11 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 				<td>The popup just closed.</td>
 				<td>No</td>
 			</tr>
+			<tr>
+				<td><code>awesomplete-highlight</code></td>
+				<td>The highlighted item just changed (in response to pressing an arrow key or via an API call).</td>
+				<td>No</td>
+			</tr>
 		</tbody>
 	</table>
 </section>


### PR DESCRIPTION
This adds an event called `awesomplete-move` which fires at the end of the `goto()` method.

I needed this because I'm displaying a long list of options in a scrollable container, and I wanted to allow the user to scroll through the list using the arrow keys. With this event I can update the scroll position to ensure the highlighted item is visible.
