### PR TITLE
Fix for open() will not open list before any input event

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -107,6 +107,8 @@ var _ = function (input, o) {
 	else {
 		this.list = this.input.getAttribute("data-list") || o.list || [];
 	}
+	
+	this.evaluate();
 
 	_.all.push(this);
 };


### PR DESCRIPTION
Reproduce:
- Don't fire any `input` event (don't key in anything)
- [Optional] Set input via JS `$('input').val('test')`
- Call `awesomplete.open()`

Issue:
- List will not open
