### PR TITLE
Allow container to be placed on a different object

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -41,7 +41,7 @@ var _ = function (input, o) {
 
 	this.container = $.create("div", {
 		className: "awesomplete",
-		around: input
+		around: o.wrapThis ? o.wrapThis : input
 	});
 
 	this.ul = $.create("ul", {


### PR DESCRIPTION
This commit allows the user to force the awesomplete container (and its elements) to be placed around an element other than the provided input.

Why? As it stands, Awesomplete is incompatible with the Insignia tag-editing library (https://github.com/bevacqua/insignia). That library requires that the input field has no siblings, and Awesomplete creates siblings.

I have no doubt that this small change will be useful for other installations as well.
