### PR TITLE
Allow user to specify pre-existing dropdown element via options param

### DIFF
--- a/awesomplete.css
+++ b/awesomplete.css
@@ -5,16 +5,16 @@
 	clip: rect(0, 0, 0, 0);
 }
 
-div.awesomplete {
+.awesomplete-wrapper {
 	display: inline-block;
 	position: relative;
 }
 
-div.awesomplete > input {
+.awesomplete-wrapper > input {
 	display: block;
 }
 
-div.awesomplete > ul {
+.awesomplete-dropdown {
 	position: absolute;
 	left: 0;
 	z-index: 1;
@@ -31,19 +31,19 @@ div.awesomplete > ul {
 	text-shadow: none;
 }
 
-div.awesomplete > ul[hidden],
-div.awesomplete > ul:empty {
+.awesomplete-dropdown[hidden],
+.awesomplete-dropdown:empty {
 	display: none;
 }
 
 @supports (transform: scale(0)) {
-	div.awesomplete > ul {
+	.awesomplete-wrapper > ul {
 		transition: .3s cubic-bezier(.4,.2,.5,1.4);
 		transform-origin: 1.43em -.43em;
 	}
-	
-	div.awesomplete > ul[hidden],
-	div.awesomplete > ul:empty {
+
+	.awesomplete-dropdown[hidden],
+	.awesomplete-dropdown:empty {
 		opacity: 0;
 		transform: scale(0);
 		display: block;
@@ -51,47 +51,47 @@ div.awesomplete > ul:empty {
 	}
 }
 
-	/* Pointer */
-	div.awesomplete > ul:before {
-		content: "";
-		position: absolute;
-		top: -.43em;
-		left: 1em;
-		width: 0; height: 0;
-		padding: .4em;
-		background: white;
-		border: inherit;
-		border-right: 0;
-		border-bottom: 0;
-		-webkit-transform: rotate(45deg);
-		transform: rotate(45deg);
-	}
+/* Pointer */
+.awesomplete-dropdown:before {
+	content: "";
+	position: absolute;
+	top: -.43em;
+	left: 1em;
+	width: 0; height: 0;
+	padding: .4em;
+	background: white;
+	border: inherit;
+	border-right: 0;
+	border-bottom: 0;
+	-webkit-transform: rotate(45deg);
+	transform: rotate(45deg);
+}
 
-	div.awesomplete > ul > li {
-		position: relative;
-		padding: .2em .5em;
-		cursor: pointer;
-	}
-	
-	div.awesomplete > ul > li:hover {
-		background: hsl(200, 40%, 80%);
-		color: black;
-	}
-	
-	div.awesomplete > ul > li[aria-selected="true"] {
-		background: hsl(205, 40%, 40%);
-		color: white;
-	}
-	
-		div.awesomplete mark {
-			background: hsl(65, 100%, 50%);
-		}
-		
-		div.awesomplete li:hover mark {
-			background: hsl(68, 100%, 41%);
-		}
-		
-		div.awesomplete li[aria-selected="true"] mark {
-			background: hsl(86, 100%, 21%);
-			color: inherit;
-		}
+.awesomplete-dropdown > li {
+	position: relative;
+	padding: .2em .5em;
+	cursor: pointer;
+}
+
+.awesomplete-dropdown > li:hover {
+	background: hsl(200, 40%, 80%);
+	color: black;
+}
+
+.awesomplete-dropdown > li[aria-selected="true"] {
+	background: hsl(205, 40%, 40%);
+	color: white;
+}
+
+.awesomplete-dropdown mark {
+	background: hsl(65, 100%, 50%);
+}
+
+.awesomplete-dropdown li:hover mark {
+	background: hsl(68, 101%, 41%);
+}
+
+.awesomplete-dropdown li[aria-selected="true"] mark {
+	background: hsl(86, 102%, 21%);
+	color: inherit;
+}

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -22,6 +22,7 @@ var _ = function (input, o) {
 		minChars: 2,
 		maxItems: 10,
 		autoFirst: false,
+		dropdown: null,
 		filter: _.FILTER_CONTAINS,
 		sort: _.SORT_BYLENGTH,
 		item: function (text, input) {
@@ -44,10 +45,18 @@ var _ = function (input, o) {
 		around: input
 	});
 
-	this.ul = $.create("ul", {
-		hidden: "",
-		inside: this.container
-	});
+	this.ul = this.dropdown ?
+		$.update(this.dropdown, {
+			hidden: '',
+			className: 'awesomplete-dropdown',
+			inside: this.container
+		}) :
+		$.create('ul', {
+			hidden: '',
+			className: 'awesomplete-dropdown',
+			inside: this.container
+		});
+
 
 	this.status = $.create("span", {
 		className: "visually-hidden",
@@ -300,29 +309,37 @@ function $$(expr, con) {
 	return slice.call((con || document).querySelectorAll(expr));
 }
 
-$.create = function(tag, o) {
-	var element = document.createElement(tag);
-
-	for (var i in o) {
-		var val = o[i];
+$.update = function(element, o) {
+  for (var i in o) {
+    var val = o[i];
 
 		if (i === "inside") {
-			$(val).appendChild(element);
+    if (i === 'inside') {
+      $(val).appendChild(element);
 		}
 		else if (i === "around") {
-			var ref = $(val);
-			ref.parentNode.insertBefore(element, ref);
-			element.appendChild(ref);
+    } else if (i === 'around') {
+      var ref = $(val);
+      ref.parentNode.insertBefore(element, ref);
+      element.appendChild(ref);
 		}
 		else if (i in element) {
-			element[i] = val;
+    } else if (i in element) {
+      element[i] = val;
 		}
 		else {
-			element.setAttribute(i, val);
-		}
-	}
+    } else {
+      element.setAttribute(i, val);
+    }
+  }
 
-	return element;
+  return element;
+};
+
+$.create = function(tag, o) {
+  var element = document.createElement(tag);
+
+  return $.update(element, o);
 };
 
 $.bind = function(element, o) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -313,22 +313,18 @@ $.update = function(element, o) {
   for (var i in o) {
     var val = o[i];
 
-		if (i === "inside") {
     if (i === 'inside') {
       $(val).appendChild(element);
-		}
-		else if (i === "around") {
-    } else if (i === 'around') {
+    }
+    else if (i === 'around') {
       var ref = $(val);
       ref.parentNode.insertBefore(element, ref);
       element.appendChild(ref);
-		}
-		else if (i in element) {
-    } else if (i in element) {
+    }
+    else if (i in element) {
       element[i] = val;
-		}
-		else {
-    } else {
+    }
+    else {
       element.setAttribute(i, val);
     }
   }


### PR DESCRIPTION
First, let me say that this package is truly awesome! I've been working on some custom autocompleters, comboboxes, and multi-input autocompleters for a work project, and the jQuery UI Autocomplete widget was quickly becoming far more of a hassle than it was worth. Awesomplete made my job _so much easier_. For that I am truly thankful.

In working on my particular use cases, however, I did find the need to add a couple of features. I thought some might be more generally useful, so I'm opening PRs for each.

This PR arose out of my need to create a multi-input autocompleter. Basically, I have four inputs which correspond to 4 sections of an account number. While the ability to override the `filter`, `item` and `replace` methods made the "hard" part quite doable, I found that I had 4 `ul`s when I really only needed the 1. Thus, I added the ability to pass in a `dropdown` option on initialization.

In short, `this.ul` will either be set to the passed in node element or a new `ul` will be created. Regardless, the `ul` dropdown will have the `awesomplete-dropdown` class, which is what the CSS now uses to handle styling.

In order to ensure the dropdown was placed _within_ the container (my own fork incorporates #16743, so the container could be created or pre-existing), I split out the attribute setting logic currently found in `$.create` into a new helper, `$.update`. This allows me to ensure that the hidden attribute is set, the `awesomplete-dropdown` class is set, and the element lives inside the container, even when the element is being passed in.

If there are any stylistic issues or you have any API suggestions, I'm happy to alter this. Or, if you feel this is unnecessary for the base project, I can keep it in my fork happily.

Thanks once again for this,
stephen
