### PR TITLE
Ensure highlighting matches the filter method chosen

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -25,10 +25,9 @@ var _ = function (input, o) {
 		filter: _.FILTER_CONTAINS,
 		sort: _.SORT_BYLENGTH,
 		item: function (text, input) {
-			var html = input === '' ? text : text.replace(_.RE(input), "<mark>$&</mark>");
-			return $.create('li', {
-				innerHTML: html,
-				'aria-selected': 'false'
+			return $.create("li", {
+				innerHTML: text.replace(_.RE(input), "<mark>$&</mark>");,
+				"aria-selected": "false"
 			});
 		},
 		replace: function (text) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -25,9 +25,10 @@ var _ = function (input, o) {
 		filter: _.FILTER_CONTAINS,
 		sort: _.SORT_BYLENGTH,
 		item: function (text, input) {
-			return $.create("li", {
-				innerHTML: text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>"),
-				"aria-selected": "false"
+			var html = input === '' ? text : text.replace(_.RE(input), "<mark>$&</mark>");
+			return $.create('li', {
+				innerHTML: html,
+				'aria-selected': 'false'
 			});
 		},
 		replace: function (text) {
@@ -246,12 +247,16 @@ _.prototype = {
 
 _.all = [];
 
+_.RE = null;
+
 _.FILTER_CONTAINS = function (text, input) {
-	return RegExp($.regExpEscape(input.trim()), "i").test(text);
+	_.RE = function(q){ return RegExp($.regExpEscape(q.trim()), 'i'); };
+	return _.RE(input).test(text);
 };
 
 _.FILTER_STARTSWITH = function (text, input) {
-	return RegExp("^" + $.regExpEscape(input.trim()), "i").test(text);
+	_.RE = function(q){ return RegExp('^' + $.regExpEscape(q.trim()), 'i'); };
+	return _.RE(input).test(text);
 };
 
 _.SORT_BYLENGTH = function (a, b) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -26,7 +26,7 @@ var _ = function (input, o) {
 		sort: _.SORT_BYLENGTH,
 		item: function (text, input) {
 			return $.create("li", {
-				innerHTML: text.replace(_.RE(input), "<mark>$&</mark>");,
+				innerHTML: text.replace(_.RE(input), "<mark>$&</mark>"),
 				"aria-selected": "false"
 			});
 		},


### PR DESCRIPTION
This is the second of my PRs. My autocompleters needed to use the `Awesomplete.FILTER_STARTSWITH` method for filtering. However, when I set that as the `filter` method, I found that the highlighting still highlighted matches anywhere in the string. In short, the default `item` function didn't respect the `filter` method.

I solved this problem by creating a `_.RE` variable which is set inside of the two `filter` methods and is re-used inside the default `item` method.

I do see one setback to this approach, however. In order for a user to override either the `filter` method or the `item` method without overriding the other and retain matching behavior, they will need to know about and use this `Awesomplete.RE` lambda. This could be solved simply via documentation, but I'm not certain how flexible this approach is, or whether you would like this. Thus why I don't currently have updated docs in the PR.

I believe that we need a simple way to ensure that the `filter` method and the `item` method are working in parallel, but I'm not yet convinced this is the best approach. So, consider this PR an initial attempt and a space to discuss other/better approaches.

stephen
