### PR TITLE
Only mark matches if input is not an empty string

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -25,8 +25,9 @@ var _ = function (input, o) {
 		filter: _.FILTER_CONTAINS,
 		sort: _.SORT_BYLENGTH,
 		item: function (text, input) {
+			var html = input === '' ? text : text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");
 			return $.create("li", {
-				innerHTML: text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>"),
+				innerHTML: html,
 				"aria-selected": "false"
 			});
 		},


### PR DESCRIPTION
This is my final PR. This is a bug that I believe was introduced with #14489. When `minChars` is set to `0`, if you have the dropdown appear before text is entered (e.g.

```
$('#awesomplete').on('focus', function() {
  awesomplete.evaluate();
});
```

), matches will be highlighted in between all the letters:
![example](https://www.dropbox.com/s/5cbpsgfw1ca7gu9/Screenshot%202015-11-23%2016.53.56.png?dl=1)

In order to fix this, I added a simple check at the top of the `item` method to ensure that `input` wasn't an empty string before running the regex replace.

This is another example where users who override `item` will need to handle this themselves, so perhaps this should be another `_.*` helper method, but I wasn't sure what you would prefer.

stephen
