### PR TITLE
Pass the original event on select

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -96,7 +96,7 @@ var _ = function (input, o) {
 			}
 
 			if (li && evt.button === 0) {  // Only select on left click
-				me.select(li);
+				me.select(li, evt);
 			}
 		}
 	}});
@@ -190,7 +190,7 @@ _.prototype = {
 		$.fire(this.input, "awesomplete-highlight");
 	},
 
-	select: function (selected) {
+	select: function (selected, originalEvent) {
 		selected = selected || this.ul.children[this.index];
 
 		if (selected) {
@@ -200,7 +200,8 @@ _.prototype = {
 				text: selected.textContent,
 				preventDefault: function () {
 					prevented = true;
-				}
+				},
+				originalEvent: originalEvent
 			});
 
 			if (!prevented) {


### PR DESCRIPTION
Sometimes we need to know the exact element that was clicked on when selecting an item in the dropdown. This PR adds the original event to the select data when firing the  `awesomplete-select` event.
