### PR TITLE
Fix issue when an element with ID of `exports` is defined in the browser.

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -383,7 +383,7 @@ if (typeof self !== "undefined") {
 }
 
 // Expose Awesomplete as a CJS module
-if (typeof exports === "object") {
+if (typeof module === "object" && module.exports) {
 	module.exports = _;
 }
 


### PR DESCRIPTION
Elements with IDs automatically have their IDs exposed. This causes errors where `module` is not defined, and yet `module.exports = _` is run. This also aligns the export with UMD.
