### PR TITLE
Fix code climate ratings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,5 +9,6 @@ ratings:
 exclude_paths:
 - "**.min.js"
 - karma*.conf.js
+- prism/**/*
 - test/**/*
 - .*

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* global Awesomplete, $:true, $$:true */
 $ = Awesomplete.$;
 $$ = Awesomplete.$$;
 


### PR DESCRIPTION
Removes `prism.js` from checks, fixes warnings about globals in `index.js`.

So we have Code Climate reports now, yay!

@LeaVerou One cool thing you might want to do is to turn on [GitHub Pull Request Integration](https://docs.codeclimate.com/docs/github-pull-request-integration).  If you do it, each PR in addition to Travis CI checks would show Code Climate checks, so you'll know immediately if something wrong with this PR from Code Climate's point of view. Like spaces used for indentation or anything else Code Climate can help you with.
