### PR TITLE
Feature/pass target to awesomplete select

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -190,7 +190,7 @@ _.prototype = {
 		$.fire(this.input, "awesomplete-highlight");
 	},
 
-	select: function (selected, target) {
+	select: function (selected, origin) {
 		selected = selected || this.ul.children[this.index];
 
 		if (selected) {
@@ -201,7 +201,7 @@ _.prototype = {
 				preventDefault: function () {
 					prevented = true;
 				},
-				target: target || selected
+				origin: origin || selected
 			});
 
 			if (!prevented) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -87,7 +87,8 @@ var _ = function (input, o) {
 	$.bind(this.input.form, {"submit": this.close.bind(this)});
 
 	$.bind(this.ul, {"mousedown": function(evt) {
-		var li = target = evt.target;
+		var target = evt.target;
+		var li = target;
 
 		if (li !== this) {
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -87,7 +87,7 @@ var _ = function (input, o) {
 	$.bind(this.input.form, {"submit": this.close.bind(this)});
 
 	$.bind(this.ul, {"mousedown": function(evt) {
-		var li = evt.target;
+		var li = target = evt.target;
 
 		if (li !== this) {
 
@@ -96,7 +96,7 @@ var _ = function (input, o) {
 			}
 
 			if (li && evt.button === 0) {  // Only select on left click
-				me.select(li, evt);
+				me.select(li, target);
 			}
 		}
 	}});
@@ -190,7 +190,7 @@ _.prototype = {
 		$.fire(this.input, "awesomplete-highlight");
 	},
 
-	select: function (selected, originalEvent) {
+	select: function (selected, target) {
 		selected = selected || this.ul.children[this.index];
 
 		if (selected) {
@@ -201,7 +201,7 @@ _.prototype = {
 				preventDefault: function () {
 					prevented = true;
 				},
-				originalEvent: originalEvent
+				target: target
 			});
 
 			if (!prevented) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -192,6 +192,7 @@ _.prototype = {
 
 	select: function (selected, target) {
 		selected = selected || this.ul.children[this.index];
+		target = target || selected;
 
 		if (selected) {
 			var prevented;

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -87,8 +87,7 @@ var _ = function (input, o) {
 	$.bind(this.input.form, {"submit": this.close.bind(this)});
 
 	$.bind(this.ul, {"mousedown": function(evt) {
-		var target = evt.target;
-		var li = target;
+		var li = evt.target;
 
 		if (li !== this) {
 
@@ -97,7 +96,7 @@ var _ = function (input, o) {
 			}
 
 			if (li && evt.button === 0) {  // Only select on left click
-				me.select(li, target);
+				me.select(li, evt.target);
 			}
 		}
 	}});

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -192,7 +192,6 @@ _.prototype = {
 
 	select: function (selected, target) {
 		selected = selected || this.ul.children[this.index];
-		target = target || selected;
 
 		if (selected) {
 			var prevented;
@@ -202,7 +201,7 @@ _.prototype = {
 				preventDefault: function () {
 					prevented = true;
 				},
-				target: target
+				target: target || selected
 			});
 
 			if (!prevented) {

--- a/test/events/mousedownSpec.js
+++ b/test/events/mousedownSpec.js
@@ -31,8 +31,8 @@ describe("mousedown event", function () {
 
 		describe("on left click", function () {
 			it("selects item", function () {
-				var event = $.fire(this.target, "mousedown", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, event);
+				$.fire(this.target, "mousedown", { button: 0 });
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
 			});
 		});
 
@@ -48,8 +48,8 @@ describe("mousedown event", function () {
 		def("target", function () { return $("mark", this.li) });
 
 		it("selects item", function () {
-			var event = $.fire(this.target, "mousedown", { button: 0 });
-			expect(this.subject.select).toHaveBeenCalledWith(this.li, event);
+			$.fire(this.target, "mousedown", { button: 0 });
+			expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
 		});
 	});
 });


### PR DESCRIPTION
Addresses #16818

I'm not happy with option named `target` though.

Since an `awesomplete-select` is fired on INPUT, inside it `this`, `event.target` and `event.currentTarget`  are references to INPUT originally. In click `target` is a reference to clicked element, but in `awesomplete-select` it may be misleading.

Eventually we need to pass 2 elements to `awesomplete-select` event for new features:
- first one is in this request - exact clicked item (child of LI or LI itself)
- second is always LI (selected element)

I can't come up with good aligned names for those 2 new fields in `awesomplete-select` event.

Any ideas?
