### PR TITLE
Pass origin element to awesomplete-select instead of event

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -97,7 +97,7 @@ var _ = function (input, o) {
 
 			if (li && evt.button === 0) {  // Only select on left click
 				evt.preventDefault();
-				me.select(li, evt);
+				me.select(li, evt.target);
 			}
 		}
 	}});
@@ -191,7 +191,7 @@ _.prototype = {
 		$.fire(this.input, "awesomplete-highlight");
 	},
 
-	select: function (selected, originalEvent) {
+	select: function (selected, origin) {
 		selected = selected || this.ul.children[this.index];
 
 		if (selected) {
@@ -202,7 +202,7 @@ _.prototype = {
 				preventDefault: function () {
 					prevented = true;
 				},
-				originalEvent: originalEvent
+				origin: origin || selected
 			});
 
 			if (!prevented) {

--- a/test/events/mousedownSpec.js
+++ b/test/events/mousedownSpec.js
@@ -31,7 +31,7 @@ describe("mousedown event", function () {
 		describe("on left click", function () {
 			it("selects item", function () {
 				var event = $.fire(this.target, "mousedown", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, event);
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
 				expect(event.defaultPrevented).toBe(true);
 			});
 		});
@@ -49,7 +49,7 @@ describe("mousedown event", function () {
 
 		it("selects item", function () {
 			var event = $.fire(this.target, "mousedown", { button: 0 });
-			expect(this.subject.select).toHaveBeenCalledWith(this.li, event);
+			expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
 			expect(event.defaultPrevented).toBe(true);
 		});
 	});


### PR DESCRIPTION
Clean version of #16819

Addresses items 2 & 3 from #16818

3 - pass exact clicked element to `awesomplete-select` instead of event object from `mousedown`
2 - pass element when item selected with keyboard as well
