### PR TITLE
Simplify opened getter

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -141,7 +141,7 @@ _.prototype = {
 	},
 
 	get opened() {
-		return this.ul && this.ul.getAttribute("hidden") == null;
+		return !this.ul.hasAttribute("hidden");
 	},
 
 	close: function () {


### PR DESCRIPTION
We can skip `this.ul` since it's always exist.
And `element.hasAttribute` works great for boolean attrs.
