### PR TITLE
Add item data to awesomplete-select event

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -189,7 +189,7 @@ _.prototype = {
 		if (selected) {
 			var allowed = $.fire(this.input, "awesomplete-select", {
 				text: selected.textContent,
-				data: this._suggestions[elementSiblingIndex(selected)],
+				data: this.suggestions[$.siblingIndex(selected)],
 				origin: origin || selected
 			});
 
@@ -210,14 +210,14 @@ _.prototype = {
 			// Populate list with options that match
 			this.ul.innerHTML = "";
 
-			this._suggestions = this._list
+			this.suggestions = this._list
 				.filter(function(item) {
 					return me.filter(item, value);
 				})
 				.sort(this.sort)
 				.slice(0, this.maxItems);
 
-			this._suggestions.forEach(function(text) {
+			this.suggestions.forEach(function(text) {
 					me.ul.appendChild(me.item(text, value));
 				});
 
@@ -291,12 +291,6 @@ function configure(instance, properties, o) {
 	}
 }
 
-function elementSiblingIndex(el) {
-	/* eslint-disable no-cond-assign */
-	for (var i = 0; el = el.previousElementSibling; i++);
-	return i;
-}
-
 // Helpers
 
 var slice = Array.prototype.slice;
@@ -360,7 +354,13 @@ $.fire = function(target, type, properties) {
 
 $.regExpEscape = function (s) {
 	return s.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
-}
+};
+
+$.siblingIndex = function (el) {
+	/* eslint-disable no-cond-assign */
+	for (var i = 0; el = el.previousElementSibling; i++);
+	return i;
+};
 
 // Initialization
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -189,6 +189,7 @@ _.prototype = {
 		if (selected) {
 			var allowed = $.fire(this.input, "awesomplete-select", {
 				text: selected.textContent,
+				data: this._suggestions[elementSiblingIndex(selected)],
 				origin: origin || selected
 			});
 
@@ -209,15 +210,15 @@ _.prototype = {
 			// Populate list with options that match
 			this.ul.innerHTML = "";
 
-			this._list
+			this._suggestions = this._list
 				.filter(function(item) {
 					return me.filter(item, value);
 				})
 				.sort(this.sort)
-				.every(function(text, i) {
-					me.ul.appendChild(me.item(text, value));
+				.slice(0, this.maxItems);
 
-					return i < me.maxItems - 1;
+			this._suggestions.forEach(function(text) {
+					me.ul.appendChild(me.item(text, value));
 				});
 
 			if (this.ul.children.length === 0) {
@@ -288,6 +289,12 @@ function configure(instance, properties, o) {
 			instance[i] = (i in o)? o[i] : initial;
 		}
 	}
+}
+
+function elementSiblingIndex(el) {
+	/* eslint-disable no-cond-assign */
+	for (var i = 0; el = el.previousElementSibling; i++);
+	return i;
 }
 
 // Helpers

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -47,6 +47,7 @@ describe("awesomplete.select", function () {
 			expect(handler).toHaveBeenCalledWith(
 				jasmine.objectContaining({
 					text: expectedTxt,
+					data: expectedTxt,
 					origin: this.selectArgument || this.subject.ul.children[0]
 				})
 			);


### PR DESCRIPTION
I made this PR as minimal as possible just to add new property to `awesomplete-select` event.

However I think if this one is merged, later we should expose `this._suggestions` as public `this.suggestions` property. It's a list of current matched items data. With just this 1 additional property we can do the following in instance methods:

``` javascript
// get current selected item data
this.suggestions[this.index];
// the same way as we can do now to get current selected item DOM element
this.ul.children[this.index];
```

Of course we can go further and add public instance properties to match suggested event properties in your comment https://github.com/LeaVerou/awesomplete/issues/16821#issuecomment-176906184
This will simplify code and be more convenient public API.

``` javascript
// same as above
this.data;
this.element;

// or since we already have this.selected:
this.selectedData;
this.selectedElement;
```
