### PR TITLE
Various list data formats and separate title/value

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -193,7 +193,7 @@ _.prototype = {
 
 		if (selected) {
 			var allowed = $.fire(this.input, "awesomplete-select", {
-				text: selected.textContent,
+				text: this.suggestions[this.index],
 				data: this.suggestions[this.index],
 				origin: origin || selected
 			});

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -273,7 +273,7 @@ _.REPLACE = function (text) {
 	this.input.value = text.value;
 };
 
-_.DATA = function (text, input) {
+_.DATA = function (text) {
 	return { title: text, value: text };
 };
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -109,17 +109,17 @@ var _ = function (input, o) {
 _.prototype = {
 	set list(list) {
 		if (Array.isArray(list)) {
-			this._list = list.map(convert);
+			this._list = list;
 		}
 		else if (typeof list === "string" && list.indexOf(",") > -1) {
-				this._list = list.split(/\s*,\s*/).map(convert);
+				this._list = list.split(/\s*,\s*/);
 		}
 		else { // Element or CSS selector
 			list = $(list);
 
 			if (list && list.children) {
 				this._list = slice.apply(list.children).map(function (el) {
-					return convert(el.textContent.trim());
+					return el.textContent.trim();
 				});
 			}
 		}
@@ -216,8 +216,8 @@ _.prototype = {
 			this.ul.innerHTML = "";
 
 			this.suggestions = this._list
-				.map(function(suggestion) {
-					return convert(me.data(suggestion, value));
+				.map(function(item) {
+					return new Suggestion(me.data(item, value));
 				})
 				.filter(function(data) {
 					return me.filter(data, value);
@@ -280,14 +280,12 @@ _.DATA = function (data, input) {
 
 // Private functions
 
-function convert(data) {
-	return new Suggestion(Array.isArray(data) ? { label: data[0], value: data[1] } : typeof data === "object" ? data : { label: data, value: data });
-}
-
 // List item data shim for 1.x API backward compatibility
 function Suggestion(data) {
-	this.label = data.label;
-	this.value = data.value;
+	var o = Array.isArray(data) ? { label: data[0], value: data[1] } : typeof data === "object" ? data : { label: data, value: data };
+
+	this.label = o.label;
+	this.value = o.value;
 }
 Suggestion.prototype = new String;
 Suggestion.prototype.toString = Suggestion.prototype.valueOf = function () {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -273,7 +273,8 @@ _.REPLACE = function (text) {
 	this.input.value = text.value;
 };
 
-_.DATA = function (text) {
+/* eslint-disable no-unused-vars */
+_.DATA = function (text, input) {
 	return { title: text, value: text };
 };
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -24,6 +24,7 @@ var _ = function (input, o) {
 		autoFirst: false,
 		filter: _.FILTER_CONTAINS,
 		sort: _.SORT_BYLENGTH,
+		data: _.DATA,
 		item: _.ITEM,
 		replace: _.REPLACE
 	}, o);
@@ -184,17 +185,21 @@ _.prototype = {
 	},
 
 	select: function (selected, origin) {
-		selected = selected || this.ul.children[this.index];
+		if (selected) {
+			this.index = $.siblingIndex(selected);
+		} else {
+			selected = this.ul.children[this.index];
+		}
 
 		if (selected) {
 			var allowed = $.fire(this.input, "awesomplete-select", {
 				text: selected.textContent,
-				data: this.suggestions[$.siblingIndex(selected)],
+				data: this.suggestions[this.index],
 				origin: origin || selected
 			});
 
 			if (allowed) {
-				this.replace(selected.textContent);
+				this.replace(this.suggestions[this.index]);
 				this.close();
 				$.fire(this.input, "awesomplete-selectcomplete");
 			}
@@ -211,6 +216,9 @@ _.prototype = {
 			this.ul.innerHTML = "";
 
 			this.suggestions = this._list
+				.map(function(item) {
+					return new Suggestion(me.data(item, value));
+				})
 				.filter(function(item) {
 					return me.filter(item, value);
 				})
@@ -262,10 +270,24 @@ _.ITEM = function (text, input) {
 };
 
 _.REPLACE = function (text) {
-	this.input.value = text;
+	this.input.value = text.value;
+};
+
+_.DATA = function (text, input) {
+	return { title: text, value: text };
 };
 
 // Private functions
+
+// List item data shim for 1.x API backward compatibility
+function Suggestion(data) {
+	this.title = data.title;
+	this.value = data.value;
+}
+Suggestion.prototype = new String;
+Suggestion.prototype.toString = Suggestion.prototype.valueOf = function () {
+	return this.title;
+};
 
 function configure(instance, properties, o) {
 	for (var i in properties) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -275,19 +275,19 @@ _.REPLACE = function (data) {
 
 /* eslint-disable no-unused-vars */
 _.DATA = function (data, input) {
-	return { title: data, value: data };
+	return { label: data, value: data };
 };
 
 // Private functions
 
 // List item data shim for 1.x API backward compatibility
 function Suggestion(data) {
-	this.title = data.title;
+	this.label = data.label;
 	this.value = data.value;
 }
 Suggestion.prototype = new String;
 Suggestion.prototype.toString = Suggestion.prototype.valueOf = function () {
-	return this.title;
+	return this.label;
 };
 
 function configure(instance, properties, o) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -109,17 +109,17 @@ var _ = function (input, o) {
 _.prototype = {
 	set list(list) {
 		if (Array.isArray(list)) {
-			this._list = list;
+			this._list = list.map(convert);
 		}
 		else if (typeof list === "string" && list.indexOf(",") > -1) {
-				this._list = list.split(/\s*,\s*/);
+				this._list = list.split(/\s*,\s*/).map(convert);
 		}
 		else { // Element or CSS selector
 			list = $(list);
 
 			if (list && list.children) {
 				this._list = slice.apply(list.children).map(function (el) {
-					return el.textContent.trim();
+					return convert(el.textContent.trim());
 				});
 			}
 		}
@@ -216,10 +216,8 @@ _.prototype = {
 			this.ul.innerHTML = "";
 
 			this.suggestions = this._list
-				.map(function(item) {
-					var suggestion = new Suggestion(convert(item));
-					var data = me.data(suggestion, value);
-					return new Suggestion(convert(data));
+				.map(function(suggestion) {
+					return convert(me.data(suggestion, value));
 				})
 				.filter(function(data) {
 					return me.filter(data, value);
@@ -283,7 +281,7 @@ _.DATA = function (data, input) {
 // Private functions
 
 function convert(data) {
-	return Array.isArray(data) ? { label: data[0], value: data[1] } : typeof data === "object" ? data : { label: data, value: data };
+	return new Suggestion(Array.isArray(data) ? { label: data[0], value: data[1] } : typeof data === "object" ? data : { label: data, value: data });
 }
 
 // List item data shim for 1.x API backward compatibility

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -217,7 +217,9 @@ _.prototype = {
 
 			this.suggestions = this._list
 				.map(function(item) {
-					return new Suggestion(me.data(item, value));
+					var suggestion = new Suggestion(convert(item));
+					var data = me.data(suggestion, value);
+					return new Suggestion(convert(data));
 				})
 				.filter(function(data) {
 					return me.filter(data, value);
@@ -275,10 +277,14 @@ _.REPLACE = function (data) {
 
 /* eslint-disable no-unused-vars */
 _.DATA = function (data, input) {
-	return { label: data, value: data };
+	return data;
 };
 
 // Private functions
+
+function convert(data) {
+	return Array.isArray(data) ? { label: data[0], value: data[1] } : typeof data === "object" ? data : { label: data, value: data };
+}
 
 // List item data shim for 1.x API backward compatibility
 function Suggestion(data) {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -219,14 +219,14 @@ _.prototype = {
 				.map(function(item) {
 					return new Suggestion(me.data(item, value));
 				})
-				.filter(function(item) {
-					return me.filter(item, value);
+				.filter(function(data) {
+					return me.filter(data, value);
 				})
 				.sort(this.sort)
 				.slice(0, this.maxItems);
 
-			this.suggestions.forEach(function(text) {
-					me.ul.appendChild(me.item(text, value));
+			this.suggestions.forEach(function(data) {
+					me.ul.appendChild(me.item(data, value));
 				});
 
 			if (this.ul.children.length === 0) {
@@ -245,12 +245,12 @@ _.prototype = {
 
 _.all = [];
 
-_.FILTER_CONTAINS = function (text, input) {
-	return RegExp($.regExpEscape(input.trim()), "i").test(text);
+_.FILTER_CONTAINS = function (data, input) {
+	return RegExp($.regExpEscape(input.trim()), "i").test(data);
 };
 
-_.FILTER_STARTSWITH = function (text, input) {
-	return RegExp("^" + $.regExpEscape(input.trim()), "i").test(text);
+_.FILTER_STARTSWITH = function (data, input) {
+	return RegExp("^" + $.regExpEscape(input.trim()), "i").test(data);
 };
 
 _.SORT_BYLENGTH = function (a, b) {
@@ -261,21 +261,21 @@ _.SORT_BYLENGTH = function (a, b) {
 	return a < b? -1 : 1;
 };
 
-_.ITEM = function (text, input) {
-	var html = input === '' ? text : text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");
+_.ITEM = function (data, input) {
+	var html = input === '' ? data : data.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");
 	return $.create("li", {
 		innerHTML: html,
 		"aria-selected": "false"
 	});
 };
 
-_.REPLACE = function (text) {
-	this.input.value = text.value;
+_.REPLACE = function (data) {
+	this.input.value = data.value;
 };
 
 /* eslint-disable no-unused-vars */
-_.DATA = function (text, input) {
-	return { title: text, value: text };
+_.DATA = function (data, input) {
+	return { title: data, value: data };
 };
 
 // Private functions

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -184,7 +184,7 @@ _.prototype = {
 		$.fire(this.input, "awesomplete-highlight");
 	},
 
-	select: function (selected, origin) {
+	select: function (selected, originalTarget) {
 		if (selected) {
 			this.index = $.siblingIndex(selected);
 		} else {
@@ -195,7 +195,7 @@ _.prototype = {
 			var allowed = $.fire(this.input, "awesomplete-select", {
 				text: this.suggestions[this.index],
 				data: this.suggestions[this.index],
-				origin: origin || selected
+				originalTarget: originalTarget || selected
 			});
 
 			if (allowed) {

--- a/index.html
+++ b/index.html
@@ -334,18 +334,12 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 	<label>Type an email: <input type="email"></label>
 	<pre class="language-markup"><code>&lt;input type="email" /></code></pre>
 	<pre class="language-javascript"><code><script>new Awesomplete($('input[type="email"]'), {
-	list: ["@aol.com", "@att.net", "@comcast.net", "@facebook.com", "@gmail.com", "@gmx.com", "@googlemail.com", "@google.com", "@hotmail.com", "@hotmail.co.uk", "@mac.com", "@me.com", "@mail.com", "@msn.com", "@live.com", "@sbcglobal.net", "@verizon.net", "@yahoo.com", "@yahoo.co.uk"],
-	item: function(text, input) {
-		var newText = input.slice(0, input.indexOf("@")) + text;
-
-		return Awesomplete.$.create("li", {
-			innerHTML: newText.replace(RegExp(input.trim(), "gi"), "<mark>$&</mark>"),
-			"aria-selected": "false"
-		});
+	list: ["aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com", "gmx.com", "googlemail.com", "google.com", "hotmail.com", "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com", "live.com", "sbcglobal.net"],
+	data: function (text, input) {
+		var newText = input.slice(0, input.indexOf("@")) + "@" + text;
+		return { title: newText, value: newText };
 	},
-	filter: function(text, input) {
-		return RegExp("^" + Awesomplete.$.regExpEscape(input.replace(/^.+?(?=@)/, ''), "i")).test(text);
-	}
+	filter: Awesomplete.FILTER_STARTSWITH
 });</script></code></pre>
 	</section>
 

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 	list: ["aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com", "gmx.com", "googlemail.com", "google.com", "hotmail.com", "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com", "live.com", "sbcglobal.net"],
 	data: function (text, input) {
 		var newText = input.slice(0, input.indexOf("@")) + "@" + text;
-		return { title: newText, value: newText };
+		return { label: newText, value: newText };
 	},
 	filter: Awesomplete.FILTER_STARTSWITH
 });</script></code></pre>

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@ awesomplete.list = ["Ada", "Java", "JavaScript", "Brainfuck", "LOLCODE", "Node.j
 	list: ["aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com", "gmx.com", "googlemail.com", "google.com", "hotmail.com", "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com", "live.com", "sbcglobal.net"],
 	data: function (text, input) {
 		var newText = input.slice(0, input.indexOf("@")) + "@" + text;
-		return { label: newText, value: newText };
+		return newText;
 	},
 	filter: Awesomplete.FILTER_STARTSWITH
 });</script></code></pre>

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -47,7 +47,7 @@ describe("awesomplete.select", function () {
 			expect(handler).toHaveBeenCalledWith(
 				jasmine.objectContaining({
 					text: expectedTxt,
-					data: expectedTxt,
+					data: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
 					origin: this.selectArgument || this.subject.ul.children[0]
 				})
 			);

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -48,7 +48,7 @@ describe("awesomplete.select", function () {
 				jasmine.objectContaining({
 					text: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
 					data: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
-					origin: this.selectArgument || this.subject.ul.children[0]
+					originalTarget: this.selectArgument || this.subject.ul.children[0]
 				})
 			);
 		});

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -46,8 +46,8 @@ describe("awesomplete.select", function () {
 
 			expect(handler).toHaveBeenCalledWith(
 				jasmine.objectContaining({
-					text: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
-					data: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
+					text: jasmine.objectContaining({ label: expectedTxt, value: expectedTxt }),
+					data: jasmine.objectContaining({ label: expectedTxt, value: expectedTxt }),
 					originalTarget: this.selectArgument || this.subject.ul.children[0]
 				})
 			);

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -46,7 +46,7 @@ describe("awesomplete.select", function () {
 
 			expect(handler).toHaveBeenCalledWith(
 				jasmine.objectContaining({
-					text: expectedTxt,
+					text: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
 					data: jasmine.objectContaining({ title: expectedTxt, value: expectedTxt }),
 					origin: this.selectArgument || this.subject.ul.children[0]
 				})

--- a/test/static/replaceSpec.js
+++ b/test/static/replaceSpec.js
@@ -5,7 +5,7 @@ describe("Awesomplete.REPLACE", function () {
 	def("instance", function() { return { input: { value: "initial" } } });
 
 	it("replaces input value", function () {
-		this.subject.call(this.instance, "JavaScript");
+		this.subject.call(this.instance, { value: "JavaScript" });
 		expect(this.instance.input.value).toBe("JavaScript");
 	});
 });


### PR DESCRIPTION
New `data` configuration property is function, which is called for each initial list item in any format to convert it to object like this one:

``` javascript
{ title: "United States", value: "US" }
```

This object is then used everywhere in API. So instead of item text `filter()`, `sort()`, `item()` and `replace()` functions now get an object with separate `title` and `value` properties.

Despite this data format change, old code will continue to work as before. This is what `Suggestion()` shim takes care of. It uses `title` property when string is expected everywhere in the API.

The only change is that now we have `value` property and it would be used in default implementation of `replace()` method. Suggestion title you see in the completer and the value inserted to the input, when the item is selected can now be fully independent.
