### PR TITLE
Removed version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "./awesomplete.css",
     "./awesomplete.js"
   ],
-  "version": "0.0.0",
   "homepage": "https://github.com/LeaVerou/awesomplete",
   "authors": [
     "Lea Verou <>"


### PR DESCRIPTION
Specifying the version in the bower.json is [deprecated](https://github.com/bower/spec/blob/master/json.md#version). Use git tags instead*. This field is ignored by Bower.

(*) Please add more tags. There's currently only one tag (v1.0.0) which refers to a version from Apr 23, 2015. Installing awesomplete with `bower install https://github.com/LeaVerou/awesomplete.git#gh-pages` without specifying a git tag is a bad idea. It always downloads the current branch which may change anytime. Could case a lot of problems when you change the API of awesomplete.

Thanks!
