### PR TITLE
Pass suggestion item to awesomplete-selectcomplete and awesomplete-highlight events

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -190,7 +190,9 @@ _.prototype = {
 			this.status.textContent = lis[i].textContent;
 		}
 
-		$.fire(this.input, "awesomplete-highlight");
+		$.fire(this.input, "awesomplete-highlight", {
+			text: this.suggestions[this.index]
+		});
 	},
 
 	select: function (selected, origin) {
@@ -201,15 +203,19 @@ _.prototype = {
 		}
 
 		if (selected) {
+			var suggestion = this.suggestions[this.index];
+
 			var allowed = $.fire(this.input, "awesomplete-select", {
-				text: this.suggestions[this.index],
+				text: suggestion,
 				origin: origin || selected
 			});
 
 			if (allowed) {
-				this.replace(this.suggestions[this.index]);
+				this.replace(suggestion);
 				this.close();
-				$.fire(this.input, "awesomplete-selectcomplete");
+				$.fire(this.input, "awesomplete-selectcomplete", {
+					text: suggestion
+				});
 			}
 		}
 	},

--- a/test/api/gotoSpec.js
+++ b/test/api/gotoSpec.js
@@ -33,7 +33,11 @@ describe("awesomplete.goto", function () {
 		var handler = $.spyOnEvent(this.subject.input, "awesomplete-highlight");
 		this.subject.goto(1);
 
-		expect(handler).toHaveBeenCalled();
+		expect(handler).toHaveBeenCalledWith(
+			jasmine.objectContaining({
+				text: jasmine.objectContaining({ label: "item2", value: "item2" })
+			})
+		);
 	});
 
 	describe("with item index > -1", function () {

--- a/test/api/selectSpec.js
+++ b/test/api/selectSpec.js
@@ -73,7 +73,11 @@ describe("awesomplete.select", function () {
 				var handler = $.spyOnEvent(this.subject.input, "awesomplete-selectcomplete");
 				this.subject.select(this.selectArgument);
 
-				expect(handler).toHaveBeenCalled();
+				expect(handler).toHaveBeenCalledWith(
+					jasmine.objectContaining({
+						text: jasmine.objectContaining({ label: expectedTxt, value: expectedTxt })
+					})
+				);
 			});
 		});
 


### PR DESCRIPTION
Similar to `awesomplete-select` event we need to know suggestion item in `awesomplete-selectcomplete` too.

I'm not sure if we also need `origin: origin || selected` same as in `awesomplete-select` event.
