### PR TITLE
Fire awesomplete-highlight event only if some item was really highlighted

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -188,11 +188,11 @@ _.prototype = {
 		if (i > -1 && lis.length > 0) {
 			lis[i].setAttribute("aria-selected", "true");
 			this.status.textContent = lis[i].textContent;
-		}
 
-		$.fire(this.input, "awesomplete-highlight", {
-			text: this.suggestions[this.index]
-		});
+			$.fire(this.input, "awesomplete-highlight", {
+				text: this.suggestions[this.index]
+			});
+		}
 	},
 
 	select: function (selected, origin) {


### PR DESCRIPTION
When you move through the list with down/up keys `awesomplete-highlight` is now triggered even after you reach the latest item and press down key again or you reach the first item and press up key again.

In those 2 cases no item became highlighted, but `awesomplete-highlight` event is fired anyway. Is it a desired behavior or is it a bug?
