### PR TITLE
Handle aria-selected attribute for mouse interaction better

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -203,6 +203,9 @@ _.prototype = {
 		}
 
 		if (selected) {
+			this.ul.children.forEach(function (unselected) {
+				unselected.setAttribute("aria-selected", "false");
+			});
 			selected.setAttribute("aria-selected", "true");
 			var suggestion = this.suggestions[this.index];
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -203,6 +203,7 @@ _.prototype = {
 		}
 
 		if (selected) {
+			selected.setAttribute("aria-selected", "true");
 			var suggestion = this.suggestions[this.index];
 
 			var allowed = $.fire(this.input, "awesomplete-select", {

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -203,8 +203,9 @@ _.prototype = {
 		}
 
 		if (selected) {
-			for (var i = 0; i < this.ul.children.length; i++) {
-				this.ul.children[i].setAttribute("aria-selected", "false");
+			var selectedLis = this.ul.querySelectorAll('[aria-selected="true"]')
+			for (var i = 0; i < selectedLis.length; i++) {
+				selectedLis[i].setAttribute("aria-selected", "false");
 			}
 			selected.setAttribute("aria-selected", "true");
 			var suggestion = this.suggestions[this.index];

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -203,9 +203,9 @@ _.prototype = {
 		}
 
 		if (selected) {
-			this.ul.children.forEach(function (unselected) {
-				unselected.setAttribute("aria-selected", "false");
-			});
+			for (var i = 0; i < this.ul.children.length; i++) {
+				this.ul.children[i].setAttribute("aria-selected", "false");
+			}
 			selected.setAttribute("aria-selected", "true");
 			var suggestion = this.suggestions[this.index];
 


### PR DESCRIPTION
This PR fixes the bug discussed in #16874.

When a user selects an item from the dropdown via the mouse, the `aria-selected` attribute is set to `true`. This PR also contains a commit that fixes a potential bug wherein if the user uses the keyboard to navigate through any of the dropdown items _and then_ selects another item with the mouse, two items would have had the `aria-selected` attribute is set to `true`. c119be7 ensures that only one dropdown item ever has the `aria-selected` attribute set to `true` after selection.
