### PR TITLE
Remove the aria-selected=true attribute from any LIs on hover.

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -79,21 +79,29 @@ var _ = function (input, o) {
 
 	$.bind(this.input.form, {"submit": this.close.bind(this)});
 
-	$.bind(this.ul, {"mousedown": function(evt) {
-		var li = evt.target;
+	$.bind(this.ul, {
+		"mousedown": function(evt) {
+			var li = evt.target;
 
-		if (li !== this) {
+			if (li !== this) {
 
-			while (li && !/li/i.test(li.nodeName)) {
-				li = li.parentNode;
+				while (li && !/li/i.test(li.nodeName)) {
+					li = li.parentNode;
+				}
+
+				if (li && evt.button === 0) {  // Only select on left click
+					evt.preventDefault();
+					me.select(li, evt.target);
+				}
 			}
-
-			if (li && evt.button === 0) {  // Only select on left click
-				evt.preventDefault();
-				me.select(li, evt.target);
+		},
+		"mouseover": function() {
+			var selectedLis = me.ul.querySelectorAll('[aria-selected="true"]')
+			for (var i = 0; i < selectedLis.length; i++) {
+				selectedLis[i].setAttribute("aria-selected", "false");
 			}
 		}
-	}});
+	});
 
 	if (this.input.hasAttribute("list")) {
 		this.list = "#" + this.input.getAttribute("list");


### PR DESCRIPTION
This is a feature PR or a bug-fix PR, depending on how you think about the current behavior I guess.

Currently, you can use the keyboard to navigate the LIs in the dropdown, marking the selected one as `aria-selected=true`. With one LI set like so via the keyboard, you could also hover over another LI:

![example](https://www.dropbox.com/s/l308rr2ce3n3o1p/Screenshot%202016-03-30%2009.10.21.png?dl=1)

This PR ensures there is only ever one item being 'highlighted' by removing the `aria-selected=true` attributes. Currently, it removes that attribute, but does not change `this.index`. I'm not sure what the preferred behavior would be. There are a few options:
1. Set `aria-selected=true` for the item being hovered over and set `this.index` to index of item being hovered over.
2. Have no `aria-selected=true` items when using mouse, always reset `this.index` to -1.
3. Have no `aria-selected=true` items when using mouse, but leave `this.index` set to whatever it was (so hitting down arrow again would select the next item in the list, leaving off from where you where before you hovered over something).
4. Leave it as it is currently.
