### PR TITLE
update init to allow single item lists

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -115,11 +115,11 @@ _.prototype = {
 				this._list = list.split(/\s*,\s*/);
 		}
 		else { // Element or CSS selector
-			list = $(list);
+			$list = $(list);
 
-			if (list && list.children) {
+			if ($list && $list.children) {
 				var items = [];
-				slice.apply(list.children).forEach(function (el) {
+				slice.apply($list.children).forEach(function (el) {
 					if (!el.disabled) {
 						var text = el.textContent.trim();
 						var value = el.value || text;
@@ -130,6 +130,9 @@ _.prototype = {
 					}
 				});
 				this._list = items;
+			}
+			else {
+				this._list = [list];
 			}
 		}
 

--- a/test/init/listSpec.js
+++ b/test/init/listSpec.js
@@ -21,6 +21,11 @@ describe("Awesomplete list", function () {
 			expect(this.subject._list).toEqual([ "From", "Inline", "List" ]);
 		});
 
+		it("assigns from a single string", function () {
+			this.subject.list = "One Item";
+			expect(this.subject._list).toEqual([ "One Item" ]);
+		});
+
 		it("assigns from element specified by selector", function () {
 			this.subject.list = "#data-list";
 			expect(this.subject._list).toEqual([


### PR DESCRIPTION
I have a use case where I am templating user data into Awesomeplete and sometimes they only have one item so far. When I join an array of one thing into a csv there is no comma so Awesomeplete doesn't  init correctly.

I added an extra init pathway for strings without comma's that just creates an array out of this single item.
