### PR TITLE
Return early from close if not open

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -147,6 +147,10 @@ _.prototype = {
 	},
 
 	close: function () {
+		if (!this.opened) {
+			return;
+		}
+
 		this.ul.setAttribute("hidden", "");
 		this.index = -1;
 

--- a/test/api/closeSpec.js
+++ b/test/api/closeSpec.js
@@ -26,4 +26,12 @@ describe("awesomplete.close", function () {
 
 		expect(handler).toHaveBeenCalled();
 	});
+
+	it("returns early if already closed", function () {
+		var handler = $.spyOnEvent(this.subject.input, "awesomplete-close");
+		this.subject.close();
+		this.subject.close();
+
+		expect(handler.calls.count()).toBe(1);
+	});
 });


### PR DESCRIPTION
If the popup is already in a closed state, return early from `Awesomplete.prototype.close` so as to guarantee that when `awesomplete-close` events get triggered, the popup _was_ actually closed.

See discussion in #16897.
