### PR TITLE
Change getter for `opened` property to use instance variable

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -12,6 +12,8 @@ var _ = function (input, o) {
 
 	// Setup
 
+	this.isOpened = false;
+
 	this.input = $(input);
 	this.input.setAttribute("autocomplete", "off");
 	this.input.setAttribute("aria-autocomplete", "list");
@@ -143,7 +145,7 @@ _.prototype = {
 	},
 
 	get opened() {
-		return !this.ul.hasAttribute("hidden");
+		return this.isOpened;
 	},
 
 	close: function (o) {
@@ -152,6 +154,7 @@ _.prototype = {
 		}
 
 		this.ul.setAttribute("hidden", "");
+		this.isOpened = false;
 		this.index = -1;
 
 		$.fire(this.input, "awesomplete-close", o || {});
@@ -159,6 +162,7 @@ _.prototype = {
 
 	open: function () {
 		this.ul.removeAttribute("hidden");
+		this.isOpened = true;
 
 		if (this.autoFirst && this.index === -1) {
 			this.goto(0);


### PR DESCRIPTION
**Problem:**  When testing code that relies on Awesomeplete, attempting to stub the constructor using [Sinon](http://sinonjs.org/) yields an error when Sinon attempts to convert the function to a string to display test results.  Here is the relevant Sinon.js code that is causing our test suite to break:

``` js
sinon.functionToString = function toString() {
    if (this.getCall && this.callCount) {
        var thisValue,
            prop;
        var i = this.callCount;

        while (i--) {
            thisValue = this.getCall(i).thisValue;

            for (prop in thisValue) {
                if (thisValue[prop] === this) { //fails here
                    return prop;
                }
            }
        }
    }

    return this.displayName || "sinon fake";
};
```

The failure occurs at `if (thisValue[prop] === this)`.  When iterating over all of the constructor's properties, it fails at `opened` because the getter relies on `this.ul.hasAttribute()`, and `this.ul` is undefined when stubbing the constructor.  I think that Sinon is making the assumption that getters wouldn't rely on the existence or values of other unrelated properties/functions, which I would agree with.

**Solution:** Create a new instance variable, `isOpened`, that is modified whenever `open()` or `close()` is called.  Return this variable instead of relying on `this.ul.hasAttribute()`.
