### PR TITLE
fix: allow selection on mobile ios

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -91,7 +91,14 @@ var _ = function (input, o) {
 			"submit": this.close.bind(this, { reason: "submit" })
 		},
 		ul: {
+			// Prevent the default mousedowm, which ensures the input is not blurred.
+			// The actual selection will happen on click. This also ensures dragging the
+			// cursor away from the list item will cancel the selection
 			"mousedown": function(evt) {
+				evt.preventDefault();
+			},
+			// The click event is fired even if the corresponding mousedown event has called preventDefault
+			"click": function(evt) {
 				var li = evt.target;
 
 				if (li !== this) {

--- a/test/events/clickSpec.js
+++ b/test/events/clickSpec.js
@@ -1,0 +1,61 @@
+describe("click event", function () {
+
+	$.fixture("plain");
+
+	subject(function () {
+		return new Awesomplete("#plain", { list: ["item1", "item2", "item3"] });
+	});
+
+	def("li", function () { return this.subject.ul.children[1] });
+
+	beforeEach(function () {
+		$.type(this.subject.input, "ite");
+		spyOn(this.subject, "select");
+	});
+
+	describe("with ul target", function () {
+		def("target", function () { return this.subject.ul });
+
+		it("does not select item", function () {
+			$.fire(this.target, "click", { button: 0 });
+			expect(this.subject.select).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("with li target", function () {
+		def("target", function () { return this.li });
+
+		describe("on left click", function () {
+			it("selects item", function () {
+				var event = $.fire(this.target, "click", { button: 0 });
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+			});
+		});
+
+		describe("on right click", function () {
+			it("does not select item", function () {
+				$.fire(this.target, "click", { button: 2 });
+				expect(this.subject.select).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe("with child of li target", function () {
+		def("target", function () { return $("mark", this.li) });
+
+		describe("on left click", function () {
+			it("selects item", function () {
+				var event = $.fire(this.target, "click", { button: 0 });
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+				expect(event.defaultPrevented).toBe(true);
+			});
+		});
+
+		describe("on right click", function () {
+			it("does not select item", function () {
+				$.fire(this.target, "click", { button: 2 });
+				expect(this.subject.select).not.toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/test/events/mousedownSpec.js
+++ b/test/events/mousedownSpec.js
@@ -16,9 +16,10 @@ describe("mousedown event", function () {
 	describe("with ul target", function () {
 		def("target", function () { return this.subject.ul });
 
-		it("does not select item", function () {
+		it("does not select item and keeps the input focussed", function () {
 			$.fire(this.target, "mousedown", { button: 0 });
 			expect(this.subject.select).not.toHaveBeenCalled();
+			expect(this.subject.input).toBe(document.activeElement);
 		});
 	});
 
@@ -26,17 +27,20 @@ describe("mousedown event", function () {
 		def("target", function () { return this.li });
 
 		describe("on left click", function () {
-			it("selects item", function () {
+			it("does not select item and keeps the input focussed", function () {
 				var event = $.fire(this.target, "mousedown", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+				expect(this.subject.select).not.toHaveBeenCalled();
 				expect(event.defaultPrevented).toBe(true);
+				expect(this.subject.input).toBe(document.activeElement);
 			});
 		});
 
 		describe("on right click", function () {
-			it("does not select item", function () {
-				$.fire(this.target, "mousedown", { button: 2 });
+			it("does not select item and keeps the input focussed", function () {
+				var event = $.fire(this.target, "mousedown", { button: 2 });
 				expect(this.subject.select).not.toHaveBeenCalled();
+				expect(event.defaultPrevented).toBe(true);
+				expect(this.subject.input).toBe(document.activeElement);
 			});
 		});
 	});
@@ -45,17 +49,20 @@ describe("mousedown event", function () {
 		def("target", function () { return $("mark", this.li) });
 
 		describe("on left click", function () {
-			it("selects item", function () {
+			it("does not select item and keeps the input focussed", function () {
 				var event = $.fire(this.target, "mousedown", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+				expect(this.subject.select).not.toHaveBeenCalled();
 				expect(event.defaultPrevented).toBe(true);
+				expect(this.subject.input).toBe(document.activeElement);
 			});
 		});
 
 		describe("on right click", function () {
-			it("does not select item", function () {
-				$.fire(this.target, "mousedown", { button: 2 });
+			it("does not select item and keeps the input focussed", function () {
+				var event = $.fire(this.target, "mousedown", { button: 2 });
 				expect(this.subject.select).not.toHaveBeenCalled();
+				expect(event.defaultPrevented).toBe(true);
+				expect(this.subject.input).toBe(document.activeElement);
 			});
 		});
 	});


### PR DESCRIPTION
On mobile ios up until ios9, no mousedown event is fired, because ios keeps the focus
on the currently active input element. However, it does fire a click event.

To work around this problem, but keep the current behavior, we add a click event
handler to the existing mousedown handler, which will now only preventDefault,
which keeps blur from firing, but allows the click handler to do the actual selection.

This new behavior additionally means that clicking and holding (dragging) the mouse away
from the autocomplete list will not result in a selection, mimicking the normal
mouse behavior.

Unit tests pass in Chrome 54
Manually tested on Win 10 Chrome 54, FF 49, Edge, IE11; on ios with 9.3.5 and 10.1
FF 

This is an alternative to #16715 and fixes #16712