### PR TITLE
Scroll to highlighted element when list container height is fixed

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -197,6 +197,9 @@ _.prototype = {
 			lis[i].setAttribute("aria-selected", "true");
 			this.status.textContent = lis[i].textContent;
 
+			// scroll to highlighted element in case parent's height is fixed 
+			this.ul.scrollTop = lis[i].offsetTop - this.ul.clientHeight + lis[i].clientHeight;
+
 			$.fire(this.input, "awesomplete-highlight", {
 				text: this.suggestions[this.index]
 			});


### PR DESCRIPTION
When the `ul` is of fixed height, navigating with keyboard does not scroll to selected element.
This PR introduces scroll to element functionality. Hope it is according to coding standards.

![awesomplete](https://cloud.githubusercontent.com/assets/9355208/21073324/d6cd5630-bf00-11e6-9e6c-0fec41da3fe9.gif)
