### PR TITLE
Hightlight correctly with multiple entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,10 @@ We can also <strong>generate list items based on user's input</strong>. See E-ma
 		return Awesomplete.FILTER_CONTAINS(text, input.match(/[^,]*$/)[0]);
 	},
 
+	item: function(text, input) {
+		return Awesomplete.ITEM(text, input.match(/[^,]*$/)[0]);
+	},
+
 	replace: function(text) {
 		var before = this.input.value.match(/^.+,\s*|/)[0];
 		this.input.value = before + text + ", ";


### PR DESCRIPTION
Fix for one of the issues in #17060.
The new `Awesomplete.data` makes sure only the current part of the input (after the comma) is used.