### PR TITLE
Mention destroy method (added by #17067) in API docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,6 +365,10 @@ We can also <strong>generate list items based on user's input</strong>. See E-ma
 				<td><code>evaluate()</code></td>
 				<td>Evaluates the current state of the widget and regenerates the list of suggestions or closes the popup if none are available. You need to call it if you dynamically set <code>list</code> while the popup is open.</td>
 			</tr>
+			<tr>
+				<td><code>destroy()</code></td>
+				<td>Clean up and remove the instance from the input.</td>
+			</tr>
 		</tbody>
 	</table>
 </section>


### PR DESCRIPTION
It was nice to be able to use the destroy method from #17067. However, there's no mention of its existence in the docs... so this PR updates the API methods section to let readers know that it's available.