### PR TITLE
Avoid script injections when rendering suggestions.

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -322,11 +322,22 @@ _.SORT_BYLENGTH = function (a, b) {
 };
 
 _.ITEM = function (text, input) {
-	var html = input.trim() === "" ? text : text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");
-	return $.create("li", {
-		innerHTML: html,
-		"aria-selected": "false"
-	});
+    input = input.trim();
+    var element = document.createElement("li");
+    element.setAttribute("aria-selected", "false");
+
+    var regex = new RegExp("("+input+")", "ig");
+    var parts = input ? text.split(regex) : [text];
+    parts.forEach(function (txt) {
+        if (input && txt.match(regex)) {
+            var match = document.createElement("mark");
+            match.textContent = txt;
+            element.appendChild(match);
+        } else {
+            element.appendChild(document.createTextNode(txt));
+        }
+    });
+    return element;
 };
 
 _.REPLACE = function (text) {


### PR DESCRIPTION
Currently (before this change), any HTML contained in the suggestion text
will be rendered by `$.create` due to the fact that `innerHTML` is being used.

This means that if there are any scripts in the suggestion text, those
scripts will be executed, which is a security risk.

For example, if the suggestion text is `<img src="fak" onerror="alert(123)">`
and the user types the text `<`, then you'll see an alert popup showing "123"
as that suggestion text gets inserted and rendered.

What this change does is to render as text (using `textContent`) the suggestion
text, while making sure that the `<mark>` elements are still rendered as HTML.