### PR TITLE
Disallow multiple dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+.idea/

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -122,7 +122,7 @@ _.prototype = {
 			this._list = list;
 		}
 		else if (typeof list === "string" && list.indexOf(",") > -1) {
-				this._list = list.split(/\s*,\s*/);
+			this._list = list.split(/\s*,\s*/);
 		}
 		else { // Element or CSS selector
 			list = $(list);

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -292,7 +292,9 @@ _.prototype = {
 			if (this.ul.children.length === 0) {
 				this.close({ reason: "nomatches" });
 			} else {
-				this.open();
+				// If the dropdown is already open, don't open again.
+				if (!this.isOpened)
+					this.open();
 			}
 		}
 		else {

--- a/test/api/evaluateSpec.js
+++ b/test/api/evaluateSpec.js
@@ -45,7 +45,8 @@ describe("awesomplete.evaluate", function () {
 			spyOn(this.subject, "open");
 			this.subject.evaluate();
 
-			expect(this.subject.open).toHaveBeenCalled();
+			if (!this.subject.isOpened)
+			    expect(this.subject.open).toHaveBeenCalled();
 		});
 
 		it("fills completer with found items", function () {


### PR DESCRIPTION
To reproduce the error:

1. In a text box with awesomeplete enabled, choose an enumerated value.
2. Blur the text box
3. Focus the text box, displaying the drowdown.
4. All without the mouse, select some portion of the text (even all of it if minChars == 0) and delete the selected text
5. Observe that a second box appears but quickly covers the original box.
6. Click one of the options closing the box.
7. Observe that another box is still present.

Sometimes there are several although I can only reliably reproduce a two-box scenario.

See screenshot below. This was observed in:
FF 52.2.1
Chrome Canary 61.0.3150.0
Chrome 59.0.3071.115

See below for a screenshot of the developer console.

![image](https://user-images.githubusercontent.com/17433509/28231859-455b12c0-68b3-11e7-8f78-9ac469e81bdd.png)

In addition a minor style typo was corrected and a Webstorm (Jetbrains IDE) hidden directory was added to .gitignore.