### PR TITLE
Optimize check li tag

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -103,7 +103,7 @@ var _ = function (input, o) {
 
 				if (li !== this) {
 
-					while (li && !/li/i.test(li.nodeName)) {
+					while (li && li.tagName !== 'LI') {
 						li = li.parentNode;
 					}
 

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -103,7 +103,7 @@ var _ = function (input, o) {
 
 				if (li !== this) {
 
-					while (li && li.tagName !== 'LI') {
+					while (li && li.tagName !== "LI") {
 						li = li.parentNode;
 					}
 


### PR DESCRIPTION
`tagName` is prefered for html elements and always in upper case. So it possible to avoid of regexp.