### PR TITLE
Ensure global Awesomplete on self is defined

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -498,6 +498,11 @@ function init() {
 	});
 }
 
+// Make sure to export Awesomplete on self when in a browser
+if (typeof self !== "undefined") {
+	self.Awesomplete = _;
+}
+
 // Are we in a browser? Check for Document constructor
 if (typeof Document !== "undefined") {
 	// DOM already loaded?
@@ -512,11 +517,6 @@ if (typeof Document !== "undefined") {
 
 _.$ = $;
 _.$$ = $$;
-
-// Make sure to export Awesomplete on self when in a browser
-if (typeof self !== "undefined") {
-	self.Awesomplete = _;
-}
 
 // Expose Awesomplete as a CJS module
 if (typeof module === "object" && module.exports) {


### PR DESCRIPTION
Fix for #17084 

Ensure global Awesomplete on self is defined before any possible call to init(), so that `Awesomplete.count` doesn't break.

I did look at adding a Karma/Jasmine test for this, but "it's hard"!

I would have to start changing all the test setup, which might not be a popular choice. I think a part of the problem is that `karma.conf.js` line 12 ensures that Awesomplete is always loaded early and thus initialised via the DOMContentLoaded event.

That means this code is never actually run in any test:
```
	if (document.readyState !== "loading") {
		init();
	}
```

Perhaps somebody with more Karma experience might be able to offer a better way to control the loading?