### PR TITLE
container function to generate container element

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -32,6 +32,7 @@ var _ = function (input, o) {
 		data: _.DATA,
 		filter: _.FILTER_CONTAINS,
 		sort: o.sort === false ? false : _.SORT_BYLENGTH,
+		container: _.CONTAINER,
 		item: _.ITEM,
 		replace: _.REPLACE
 	}, o);
@@ -40,10 +41,7 @@ var _ = function (input, o) {
 
 	// Create necessary elements
 
-	this.container = $.create("div", {
-		className: "awesomplete",
-		around: input
-	});
+	this.container = this.container(input);
 
 	this.ul = $.create("ul", {
 		hidden: "hidden",
@@ -350,6 +348,13 @@ _.SORT_BYLENGTH = function (a, b) {
 
 	return a < b? -1 : 1;
 };
+
+_.CONTAINER = function (input) {
+	return $.create("div", {
+		className: "awesomplete",
+		around: input
+	});
+}
 
 _.ITEM = function (text, input, item_id) {
 	var html = input.trim() === "" ? text : text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");

--- a/index.html
+++ b/index.html
@@ -242,6 +242,12 @@ new Awesomplete(input, {
 				<td>Sorted by length first, order second.</td>
 			</tr>
 			<tr>
+				<td><code>container</code></td>
+				<td>Controls how list container element generated.</td>
+				<td>Function that takes one parameter, the user’s input and returns an element.</td>
+				<td>Generates <code>&lt;div></code> with class <code>awesomplete</code></td>
+			</tr>
+			<tr>
 				<td><code>item</code></td>
 				<td>Controls how list items are generated.</td>
 				<td>Function that takes two parameters, the first one being the suggestion text and the second one the user’s input and returns a list item.</td>


### PR DESCRIPTION
I've added a `container` function to options that will allow client to provide a different container element. The default version of `container` function creates container element as before. I believe this is in line with the `item` function that customizes creating item elements.

This addresses my use case where container element cannot reuse the input element parent
because the input parent clips container's content. It also addresses a case when input element has to be next to it's original siblings.

It also solves #17086 & #16718

Thank you for consideration.