### PR TITLE
change reference to itself to be _ as everywhere else

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -11,8 +11,8 @@ var _ = function (input, o) {
 	var me = this;
     
     // Keep track of number of instances for unique IDs
-    Awesomplete.count = (Awesomplete.count || 0) + 1;
-    this.count = Awesomplete.count;
+    _.count = (_.count || 0) + 1;
+    this.count = _.count;
 
 	// Setup
 


### PR DESCRIPTION
Awesomplete should refer to itself as `_` instead of `Awesomplete`
because the latter is only globally available in the browser

While this is mostly to be consistent - everywhere else `_` is used internally - the issue happens to affects tests that I run outside browser.

Thank you for consideration.