### PR TITLE
Add "autocomplete" as initialization option

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -19,7 +19,7 @@ var _ = function (input, o) {
 	this.isOpened = false;
 
 	this.input = $(input);
-	this.input.setAttribute("autocomplete", "off");
+	this.input.setAttribute("autocomplete", "awesomplete");
 	this.input.setAttribute("aria-owns", "awesomplete_list_" + this.count);
 	this.input.setAttribute("role", "combobox");
 

--- a/test/init/htmlSpec.js
+++ b/test/init/htmlSpec.js
@@ -10,7 +10,7 @@ describe("Html modifications", function () {
 	});
 
 	it("turns native autocompleter off", function () {
-		expect(this.subject.input.getAttribute("autocomplete")).toBe("off");
+		expect(this.subject.input.getAttribute("autocomplete")).toBe("awesomplete");
 	});
 
 	describe("HTML tweaks", function () {


### PR DESCRIPTION
Hi 👋 !

I have the same issue as #17155, but I suggest a slightly different modification. I don't know if this is a priority but I feared that by modifying the default `"autocomplete"` value we may break some users' usage (even if this is an undocumented behaviour). Moreover by defaulting to `"off"` we are still following the [best practices](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).

What do you think ?


And one more question, do I need to update the built/generated files ?