### PR TITLE
Allow overriding the default Suggestion class

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -38,6 +38,7 @@ var _ = function (input, o) {
 		container: _.CONTAINER,
 		item: _.ITEM,
 		replace: _.REPLACE,
+		suggestion: Suggestion,
 		tabSelect: false
 	}, o);
 
@@ -305,7 +306,7 @@ _.prototype = {
 
 			this.suggestions = this._list
 				.map(function(item) {
-					return new Suggestion(me.data(item, value));
+					return new me.suggestion(me.data(item, value));
 				})
 				.filter(function(item) {
 					return me.filter(item, value);

--- a/index.html
+++ b/index.html
@@ -283,6 +283,12 @@ We can also <strong>generate list items based on user's input</strong>. See E-ma
 				</td>
 				<td><code class="language-javascript">Awesomplete.DATA</code>: Identity function which just returns the original list item.</td>
 			</tr>
+			<tr>
+				<td><code>suggestion</code></td>
+				<td>Controls the class used to create new Suggestions.</td>
+				<td>A class that responds to the <code>label</code>, <code>value</code>, and <code>length</code> properties and the <code>toString</code> and <code>valueOf</code> methods.</td>
+				<td><code>Suggestion</code>: A basic class, protoyped from <code>String</code>, which provides the requisite functionality.</td>
+			</tr>
 		</tbody>
 	</table>
 </section>


### PR DESCRIPTION
I'm using Awesomplete for 8 separate dropdowns that need custom `li` html, and being able to use a custom Suggestion implementation for each item type would really help. Unfortunately, the creation of a Suggestion is hard-coded, so here's a pull request to make it a config option like `_.DATA` or `_.ITEM`.

I see there's been a previous pull request about spreading list props (#17001) and I think this would help in that area without causing any backwards-compatibility problems or over-complication for people who don't need this feature.