### PR TITLE
feat: Add `originalEvent` property to select events

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -77,10 +77,10 @@ var _ = function (input, o) {
 				if(me.opened) {
 					if (c === 13 && me.selected) { // Enter
 						evt.preventDefault();
-						me.select();
+						me.select(undefined, undefined, evt);
 					}
 					else if (c === 9 && me.selected && me.tabSelect) {
-						me.select();
+						me.select(undefined, undefined, evt);
 					}
 					else if (c === 27) { // Esc
 						me.close({ reason: "esc" });
@@ -114,7 +114,7 @@ var _ = function (input, o) {
 
 					if (li && evt.button === 0) {  // Only select on left click
 						evt.preventDefault();
-						me.select(li, evt.target);
+						me.select(li, evt.target, evt);
 					}
 				}
 			}
@@ -269,7 +269,7 @@ _.prototype = {
 		}
 	},
 
-	select: function (selected, origin) {
+	select: function (selected, origin, originalEvent) {
 		if (selected) {
 			this.index = $.siblingIndex(selected);
 		} else {
@@ -281,14 +281,16 @@ _.prototype = {
 
 			var allowed = $.fire(this.input, "awesomplete-select", {
 				text: suggestion,
-				origin: origin || selected
+				origin: origin || selected,
+				originalEvent: originalEvent
 			});
 
 			if (allowed) {
 				this.replace(suggestion);
 				this.close({ reason: "select" });
 				$.fire(this.input, "awesomplete-selectcomplete", {
-					text: suggestion
+					text: suggestion,
+					originalEvent: originalEvent
 				});
 			}
 		}

--- a/index.html
+++ b/index.html
@@ -317,12 +317,12 @@ We can also <strong>generate list items based on user's input</strong>. See E-ma
 		<tbody>
 			<tr>
 				<td><code>awesomplete-select</code></td>
-				<td>The user has made a selection (either via pressing enter or clicking on an item), but it has not been applied yet. Callback will be passed an object with <code>text</code> (selected suggestion) and <code>origin</code> (DOM element) properties.</td>
+				<td>The user has made a selection (either via pressing enter or clicking on an item), but it has not been applied yet. Callback will be passed an object with <code>text</code> (selected suggestion), <code>origin</code> (DOM element) properties and <code>originalEvent</code> the original triggering DOM event.</td>
 				<td>Yes. The selection will not be applied and the popup will not close.</td>
 			</tr>
 			<tr>
 				<td><code>awesomplete-selectcomplete</code></td>
-				<td>The user has made a selection (either via pressing enter or clicking on an item), and it has been applied. Callback will be passed an object with a <code>text</code> property containing the selected suggestion.</td>
+				<td>The user has made a selection (either via pressing enter or clicking on an item), and it has been applied. Callback will be passed an object with a <code>text</code> property containing the selected suggestion and <code>originalEvent</code> the original triggering DOM event.</td>
 				<td>No</td>
 			</tr>
 			<tr>

--- a/test/events/clickSpec.js
+++ b/test/events/clickSpec.js
@@ -28,7 +28,7 @@ describe("click event", function () {
 		describe("on left click", function () {
 			it("selects item", function () {
 				var event = $.fire(this.target, "click", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target, event);
 			});
 		});
 
@@ -46,7 +46,7 @@ describe("click event", function () {
 		describe("on left click", function () {
 			it("selects item", function () {
 				var event = $.fire(this.target, "click", { button: 0 });
-				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target);
+				expect(this.subject.select).toHaveBeenCalledWith(this.li, this.target, event);
 				expect(event.defaultPrevented).toBe(true);
 			});
 		});


### PR DESCRIPTION
Allows distinguishing between click and keydown selection.

Should close #17179