### PR TITLE
Add documentation: TabSelect property

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,13 @@ new Awesomplete(input, {
 				<td>Boolean</td>
 				<td>false</td>
 			</tr>
+			<tr>
+				<td><code>tabSelect</code></td>
+				<td><code>data-tabSelect</code></td>
+				<td>Should the first element be selected when the user hits the TAB key when the field has focus?></td>
+				<td>Boolean</td>
+				<td>false</td>
+			</tr>
 		</tbody>
 	</table>
 


### PR DESCRIPTION
In commit da06e45f829a3d5c0323a9d0d9d5ff2def4825b5 the functionality to select the first item on tab is added, but this can't be found in the documentation. This change adds that documentation.