### PR TITLE
Update documentation on behaviour of `destroy()`

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,7 +387,7 @@ We can also <strong>generate list items based on user's input</strong>. See E-ma
 			</tr>
 			<tr>
 				<td><code>destroy()</code></td>
-				<td>Clean up and remove the instance from the input.</td>
+				<td>Clean up and remove the instance from the input. The container is only removed if it wasn't manually set but created by Awesomplete.</td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
Update documentation of `destroy()` to clarify that the container is only removed if it wasn't manually set via the `container` property.

This brings the documentation in line with the [inline code comment](https://github.com/LeaVerou/awesomplete/blob/12c913ba7ffbcbe033f580694fd5a7c996f4d001/awesomplete.js#L213-L220).