### PR TITLE
Add ignore diacritics capabilities 

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -376,13 +376,14 @@ _.CONTAINER = function (input) {
 }
 
 _.ITEM = function (text, input, item_id) {
-	inupt = this.ignoreDiacritics ? removeDiacritics(input) : input;
+	input = this.ignoreDiacritics ? removeDiacritics(input) : input;
 	var text_comp = this.ignoreDiacritics ? removeDiacritics(text) : text;
 
 	// shadow = text without diacritics (for comparison)
 	var shadow = input.trim() === "" ? text : text_comp.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&<mark>");
 	
 	// Display diacritics in suggestions (html = with diacritics)
+	let html = "";
 	if (shadow.indexOf("<mark>") !== -1) {
 		shadow = shadow.split("<mark>")
 		html = text.slice(0, shadow[0].length)

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -39,7 +39,8 @@ var _ = function (input, o) {
 		item: _.ITEM,
 		replace: _.REPLACE,
 		tabSelect: false,
-		listLabel: "Results List"
+		listLabel: "Results List",
+		ignoreDiacritics: true
 	}, o);
 
 	this.index = -1;
@@ -312,6 +313,8 @@ _.prototype = {
 					return new Suggestion(me.data(item, value));
 				})
 				.filter(function(item) {
+					item = me.ignoreDiacritics ? removeDiacritics(item) : item;
+					value = me.ignoreDiacritics ? removeDiacritics(value) : value;
 					return me.filter(item, value);
 				});
 
@@ -322,8 +325,8 @@ _.prototype = {
 			this.suggestions = this.suggestions.slice(0, this.maxItems);
 
 			this.suggestions.forEach(function(text, index) {
-					me.ul.appendChild(me.item(text, value, index));
-				});
+				me.ul.appendChild(me.item(text, value, index));
+			});
 
 			if (this.ul.children.length === 0) {
 
@@ -373,7 +376,22 @@ _.CONTAINER = function (input) {
 }
 
 _.ITEM = function (text, input, item_id) {
-	var html = input.trim() === "" ? text : text.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&</mark>");
+	inupt = this.ignoreDiacritics ? removeDiacritics(input) : input;
+	var text_comp = this.ignoreDiacritics ? removeDiacritics(text) : text;
+
+	// shadow = text without diacritics (for comparison)
+	var shadow = input.trim() === "" ? text : text_comp.replace(RegExp($.regExpEscape(input.trim()), "gi"), "<mark>$&<mark>");
+	
+	// Display diacritics in suggestions (html = with diacritics)
+	if (shadow.indexOf("<mark>") !== -1) {
+		shadow = shadow.split("<mark>")
+		html = text.slice(0, shadow[0].length)
+				 + "<mark>" + text.slice(shadow[0].length, shadow[0].length + shadow[1].length)
+				 + "</mark>" + text.slice(shadow[0].length + shadow[1].length)
+	} else {
+		html = shadow;
+	}
+
 	return $.create("li", {
 		innerHTML: html,
 		"role": "option",
@@ -427,6 +445,10 @@ function configure(instance, properties, o) {
 			instance[i] = (i in o)? o[i] : initial;
 		}
 	}
+}
+
+function removeDiacritics(string) {
+  return string.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
 
 // Helpers


### PR DESCRIPTION
# Description

Added the possibility to ignore characters with diacritics.
When the user inputs a string, it should match with the items in the list whether or not the input or the items have accented characters.

Fixes #17187 
Fixes #17234 

## Type of changes

- [x] New feature (non-breaking change that adds functionality)

This PR introduces a new option **Awesomplete.ignoreDiacritics** (boolean, default *true*).
When set to *true*, it allows matching accented characters against non-accented characters.
When set to *false*, it requires characters to be the same to match.

This is an implementation of [David Calhoun's blog post](https://www.davidbcalhoun.com/2019/matching-accented-strings-in-javascript/).