### PR TITLE
Prevent Tab key resulting in list element being skipped when `tabSelect: true`

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -72,22 +72,24 @@ var _ = function (input, o) {
 			"input": this.evaluate.bind(this),
 			"blur": this.close.bind(this, { reason: "blur" }),
 			"keydown": function(evt) {
-				evt.preventDefault();
 				var c = evt.keyCode;
 
 				// If the dropdown `ul` is in view, then act on keydown for the following keys:
 				// Enter / Esc / Up / Down
 				if(me.opened) {
 					if (c === 13 && me.selected) { // Enter
+						evt.preventDefault();
 						me.select(undefined, undefined, evt);
 					}
 					else if (c === 9 && me.selected && me.tabSelect) {
+						evt.preventDefault();
 						me.select(undefined, undefined, evt);
 					}
 					else if (c === 27) { // Esc
 						me.close({ reason: "esc" });
 					}
 					else if (c === 38 || c === 40) { // Down/Up arrow
+						evt.preventDefault();
 						me[c === 38? "previous" : "next"]();
 					}
 				}

--- a/awesomplete.js
+++ b/awesomplete.js
@@ -72,13 +72,13 @@ var _ = function (input, o) {
 			"input": this.evaluate.bind(this),
 			"blur": this.close.bind(this, { reason: "blur" }),
 			"keydown": function(evt) {
+				evt.preventDefault();
 				var c = evt.keyCode;
 
 				// If the dropdown `ul` is in view, then act on keydown for the following keys:
 				// Enter / Esc / Up / Down
 				if(me.opened) {
 					if (c === 13 && me.selected) { // Enter
-						evt.preventDefault();
 						me.select(undefined, undefined, evt);
 					}
 					else if (c === 9 && me.selected && me.tabSelect) {
@@ -88,7 +88,6 @@ var _ = function (input, o) {
 						me.close({ reason: "esc" });
 					}
 					else if (c === 38 || c === 40) { // Down/Up arrow
-						evt.preventDefault();
 						me[c === 38? "previous" : "next"]();
 					}
 				}

--- a/test/events/keydownSpec.js
+++ b/test/events/keydownSpec.js
@@ -90,7 +90,7 @@ describe("tabSelect option true ", function () {
 
 		spyOn(this.subject, "select");
 		$.keydown(this.subject.input, $.k.TAB);
-
 		expect(this.subject.select).toHaveBeenCalled();
+		expect(this.subject.select.calls.mostRecent().args[2].defaultPrevented).toBe(true);
 	});
 })


### PR DESCRIPTION
It seems the branch for handling a `tab` key event if `tabSelect: true` is missing an `evt.preventDefault()`, which results in an item being skipped when autocompletes are created in a list.

To fix this, I believe we could call `evt.preventDefault()` in all branches of the procedure, instead of only some.

I have manually tested that this fixes the problem on our UI. The existing tests also appear to pass. If this change seems to make sense, I can look into adding a test.

### Example
**Initial state**
![image](https://user-images.githubusercontent.com/12681350/121836647-bf2dcb00-cc88-11eb-8c6a-625e2657e453.png)

**(Current behavior): final state after pressing tab:**
![image](https://user-images.githubusercontent.com/12681350/121836881-395e4f80-cc89-11eb-979d-18431b6ccbeb.png)

**(Expected behavior): final state after pressing tab:**
![image](https://user-images.githubusercontent.com/12681350/121836792-074ced80-cc89-11eb-97e5-ed19c3fbd8f4.png)
