### PR TITLE
Add aria-controls attribute to input element

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -22,6 +22,7 @@ var _ = function (input, o) {
 	this.input.setAttribute("autocomplete", "off");
 	this.input.setAttribute("aria-autocomplete", "list");
 	this.input.setAttribute("aria-expanded", "false");
+	this.input.setAttribute("aria-controls", "awesomplete_list_" + this.count);
 	this.input.setAttribute("aria-owns", "awesomplete_list_" + this.count);
 	this.input.setAttribute("role", "combobox");
 
@@ -230,7 +231,8 @@ _.prototype = {
 		this.input.removeAttribute("autocomplete");
 		this.input.removeAttribute("aria-autocomplete");
 		this.input.removeAttribute("aria-expanded");
-		this.input.removeAttribute("aria-owns");
+		this.input.removeAttribute("aria-controls");
+		this.input.removeAttribute("aria-owns");		
 		this.input.removeAttribute("role");
 
 		//remove this awesomeplete instance from the global array of instances


### PR DESCRIPTION
Currently using aria-owns attribute to relate input and listbox, per ARIA 1.0. Added use of aria-controls, per ARIA 1.1. 
Left aria-owns in place for B/C and also makes sense as list is a sibling of input anyway.